### PR TITLE
metainfo: Increase minimum display length requirement to 550

### DIFF
--- a/flatpak/io.github.ostapkonst.HashVerifier.metainfo.xml
+++ b/flatpak/io.github.ostapkonst.HashVerifier.metainfo.xml
@@ -47,7 +47,7 @@
     <control>touch</control>
   </recommends>
   <requires>
-    <display_length compare="ge">360</display_length>
+    <display_length compare="ge">550</display_length>
   </requires>
   <categories>
     <category>Utility</category>


### PR DESCRIPTION
Thank you for creating this nice app!

The display_length value should be in line with the minimum window width, which here appears to be 550px: 
<img width="831" height="680" alt="Screenshot From 2026-03-22 18-28-37" src="https://github.com/user-attachments/assets/995fcc9d-5b1d-4fd5-a47f-4323b4caed32" />
